### PR TITLE
fix: err_backward should be defined.

### DIFF
--- a/ezsynth/stylizer.py
+++ b/ezsynth/stylizer.py
@@ -133,7 +133,7 @@ class Stylizer:
                 style_forward, err_forward = _stylize(start_idx, end_idx, style_start, style_end, gpos,
                                                                         gpos_rev, imgseq, edge, flow, output_path=output_dir)
                                     
-                style_backward, style_forward = _stylize( end_idx, start_idx, style_end, style_start, gpos,
+                style_backward, err_backward = _stylize( end_idx, start_idx, style_end, style_start, gpos,
                                                                         gpos_rev, imgseq, edge, flow, output_path=output_dir)
                     
 

--- a/ezsynth/stylizer.py
+++ b/ezsynth/stylizer.py
@@ -46,7 +46,8 @@ class Stylizer:
 
         self.num_styles = len(self.styles)
         self.num_frames = len(self.imgsequence)
-
+        self.imgindexes = set(range(self.num_frames))
+        
         self.begFrame = 0
         self.endFrame = self.num_frames - 1
 


### PR DESCRIPTION
Getting
"ERROR:root:An error occurred: cannot access local variable 'err_backward' where it is not associated with a value" and
"ERROR:root:An error occurred: 'Stylizer' object has no attribute 'imgindexes'".
